### PR TITLE
Resolved gcc compiler warning

### DIFF
--- a/lib/CException.h
+++ b/lib/CException.h
@@ -62,7 +62,7 @@ extern volatile CEXCEPTION_FRAME_T CExceptionFrames[];
         CExceptionFrames[MY_ID].pFrame = (jmp_buf*)(&NewFrame);     \
         CExceptionFrames[MY_ID].Exception = CEXCEPTION_NONE;        \
         if (setjmp(NewFrame) == 0) {                                \
-            if (&PrevFrame) 
+            if (1)
 
 //Catch (see C file for explanation)
 #define Catch(e)                                                    \


### PR DESCRIPTION
Resolved warning that the address of `PrevFrame` will always evaluate to `true`.
