### PR TITLE
modify variable i to make test slightly more useful

### DIFF
--- a/test/TestException.c
+++ b/test/TestException.c
@@ -349,10 +349,12 @@ void test_AbilityToExitTryWithoutThrowingAnError(void)
     Try
     {
         ExitTry();
+        i = 1;
         TEST_FAIL_MESSAGE("Should Have Exited Try Before This");
     }
     Catch(e)
     {
+        i = 2;
         TEST_FAIL_MESSAGE("Should Not Have Been Caught");
     }
 


### PR DESCRIPTION
'i' is not modified because it exits try and no exception was thrown that was supposed to be caught. 