### PR TITLE
Using memcmp to test equality when comparing a caught exception again…

### DIFF
--- a/lib/CException.h
+++ b/lib/CException.h
@@ -94,7 +94,7 @@ extern volatile CEXCEPTION_FRAME_T CExceptionFrames[];
         CExceptionFrames[MY_ID].pFrame = PrevFrame;                 \
         CEXCEPTION_HOOK_AFTER_TRY;                                  \
     }                                                               \
-    if (CExceptionFrames[CEXCEPTION_GET_ID].Exception != CEXCEPTION_NONE)
+    if (memcmp((void*)&CExceptionFrames[CEXCEPTION_GET_ID].Exception, (void*)&CEXCEPTION_NONE, sizeof(CEXCEPTION_NONE)) != 0) \
 
 //Throw an Error
 void Throw(CEXCEPTION_T ExceptionID);


### PR DESCRIPTION
…st CEXCEPTION_NONE. This allows CEXCEPTION_T to be a struct and in my case carry file name and line number information along with an enermerated code. This adds a little weight to the object, but 2 ints and a pointer are not that hefty.