### PR TITLE
docs: fix simple typo, othertimes -> other times

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ location was updated and not just a register unless the variable is marked volat
 ### Memory Management
 
 Memory which is `malloc`'d within a `Try` block is not automatically released when an error is thrown. This 
-will sometimes be desirable, and othertimes may not. It will be the responsibility of the code you put in 
+will sometimes be desirable, and other times may not. It will be the responsibility of the code you put in 
 the `Catch` block to perform this kind of cleanup.
 
 There's just no easy way to track `malloc`'d memory, etc., without replacing or wrapping `malloc` 

--- a/docs/CException.md
+++ b/docs/CException.md
@@ -145,7 +145,7 @@ to successfully utilize this library:
 
 3. Memory which is `malloc`'d or `new`'d is not automatically released
    when an error is thrown.  This will sometimes be desirable, and
-   othertimes may not.  It will be the responsibility of the `Catch`
+   other times may not.  It will be the responsibility of the `Catch`
    block to perform this kind of cleanup.
 
    *Why?*


### PR DESCRIPTION
There is a small typo in README.md, docs/CException.md.

Should read `other times` rather than `othertimes`.

