### PR TITLE
Fix "clobbered variable" compiler warning (-Wclobbered) in example code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ transferred to the Catch block. A silly example:
 
 ```
 void SillyExampleWhichPrintsZeroThroughFive(void) {
-  CEXCEPTION_T e;
+  volatile CEXCEPTION_T e;
   int i;
   while (i = 0; i < 6; i++) {
     Try {


### PR DESCRIPTION
This MR updates the example code snippet in the documentation according to https://github.com/ThrowTheSwitch/Unity/pull/600.